### PR TITLE
🚨 Fix: Challenge Error in "Two Sum Problem" (#9)

### DIFF
--- a/challenges/two-sum-problem-mcasz7b2/FIX_INSTRUCTIONS.md
+++ b/challenges/two-sum-problem-mcasz7b2/FIX_INSTRUCTIONS.md
@@ -1,0 +1,49 @@
+# 🚨 Challenge-Fehler: Behebungsanleitung
+
+## 📋 Challenge-Informationen
+- **Titel:** Two Sum Problem
+- **ID:** two-sum-problem-mcasz7b2
+- **Fehlertyp:** template
+- **GitHub Issue:** #9
+
+## ❌ Fehlermeldung
+```
+Keine ah
+```
+
+## 🛠️ Behebungsschritte
+
+### 1. Diagnose
+Untersuche die Template-Generierung. Häufige Probleme sind:
+- Falsche Klassennamen oder Funktionsnamen
+- Fehlende Import-Anweisungen
+- Inkonsistente Pfade oder Dateipfade
+
+### 2. Lösungsansätze
+Je nach Fehlerursache:
+
+- **Template-Fehler:** Überprüfe die Template-Dateien auf Syntaxfehler oder falsche Klassennamen
+- **Laufzeit-Fehler:** Überprüfe die Tests auf falsche Annahmen oder Randfälle
+- **Kompilierungsfehler:** Überprüfe Sprachversionen und Abhängigkeiten
+- **Validierungsfehler:** Überprüfe die Konsistenz zwischen TestRunner und Tests
+
+### 3. Test der Lösung
+1. Korrigiere die Fehler in einem lokalen Branch
+2. Teste die korrigierten Dateien mit dem TestRunner
+3. Wenn erfolgreich, committe deine Änderungen zu diesem Branch
+4. Führe Tests mit mehreren Beispiellösungen durch
+
+### 4. Finalisierung
+1. Aktualisiere die `challenge.json` um den Status zurückzusetzen
+2. Setze `isResolved: true` in der `error-report.json` Datei
+3. Schließe den zugehörigen GitHub Issue
+4. Führe einen PR-Review durch und merge in den Hauptzweig
+
+## 💡 Tipps
+
+- Überprüfe immer die Konsistenz zwischen Klassenname, Methodenname und deren Aufrufen
+- Stelle sicher, dass die Testumgebung korrekt eingerichtet ist
+- Überprüfe, ob die Fehler sprachspezifisch sind
+- Vergleiche mit funktionierenden Challenges derselben Sprache
+
+> Dieser Fix-Branch wurde automatisch vom Coding Challenges Extension Error-Handler erstellt.

--- a/challenges/two-sum-problem-mcasz7b2/error-report.json
+++ b/challenges/two-sum-problem-mcasz7b2/error-report.json
@@ -1,0 +1,11 @@
+{
+  "id": "two-sum-problem-mcasz7b2",
+  "title": "Two Sum Problem",
+  "errorMessage": "Keine ah",
+  "errorType": "template",
+  "timestamp": "2025-06-24T18:12:56.052Z",
+  "isResolved": false,
+  "reportedBy": "Jodo2410",
+  "issueNumber": 9,
+  "issueUrl": "https://github.com/Jodo2410/Code-Challenge/issues/9"
+}


### PR DESCRIPTION
## 🔧 Fix for Challenge Error

This PR contains the fix for an error in challenge "Two Sum Problem" (ID: two-sum-problem-mcasz7b2).

### 🚨 Error Information
- **Type:** template
- **Message:** Keine ah
- **Reported:** 2025-06-24T18:12:56.052Z

### 🔍 Related Issue
Fixes #9

### 🛠️ Actions Taken
- [ ] Fixed template code
- [ ] Updated tests
- [ ] Improved error handling
- [ ] Added validation

Please review the changes and merge if the fix is acceptable.
